### PR TITLE
adding the ability to pass options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  build_and_test:
+    name: Rust project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.57"
 serde_yaml = "0.8.13"
 wasm-bindgen = { version = "0.2.64", features = ["serde-serialize"] }
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,84 @@ results = matter(long_markdown);
 console.log(results.data.title);
 ```
 
+## Options
+
+### options.excerpt
+
+**Type**: `Boolean`
+
+**Default**: `false`
+
+Extracts an excerpt that directly follows front-matter, or is the first thing in the string if no front-matter exists.
+
+If set to `excerpt: true`, it will look for the frontmatter delimiter, `---` and grab everything leading up to it.
+
+**Example**
+
+```js
+const str = '---\nfoo: bar\n---\nThis is an excerpt.\n---\nThis is content';
+const file = matter(str, { excerpt: true });
+```
+
+Results in:
+
+```js
+{
+  content: 'This is an excerpt.\n---\nThis is content',
+  data: { foo: 'bar' },
+  excerpt: 'This is an excerpt.\n'
+}
+```
+
+### options.excerpt_separator
+
+**Type**: `String`
+
+**Default**: `---`
+
+Allows for a custom separator to use for excerpts.
+
+**Example**
+
+```js
+const str = '---\nfoo: bar\n---\nThis is an excerpt.\n<!-- end -->\nThis is content';
+console.log(matter(str, {excerpt_separator: '<!-- end -->'}));
+```
+
+Results in:
+
+```js
+{
+  content: 'This is an excerpt.\n<!-- end -->\nThis is content',
+  data: { foo: 'bar' },
+  excerpt: 'This is an excerpt.\n'
+}
+```
+
+### options.delimiters
+
+**Type**: `String`
+
+**Default**: `---`
+
+Allows for a custom delimiter to define the frontmatter.
+
+**Example:**
+
+```js
+const str = '~~~\nfoo: bar\n~~~\nThis is content';
+console.log(matter(str, {delimiter: '~~~'}));
+```
+Results in:
+
+```js
+{
+  content: 'This is content',
+  data: { foo: 'bar' },
+  excerpt: ''
+}
+```
+
 ## Develop
 
 Modify `src/lib.rs` and run `make build` to update the package. Can run tests using the included `index.js` file. Or write tests and run `make test`.

--- a/index.js
+++ b/index.js
@@ -57,3 +57,53 @@ console.log("\n");
 
 data = matter(long_markdown);
 console.log(data.data.title)
+console.log("\n");
+
+console.log("################ TEST 4 ################");
+console.log(`{
+  content: 'this is an excerpt!\n\n---\n\nthis is content!',
+  data: {}
+  excerpt: 'this is an excerpt!\n\n'
+}`);
+console.log(matter("this is an excerpt!\n---\nthis is a content!"))
+
+console.log("################ TEST 5 ################");
+opt = {excerpt: true};
+
+console.log(matter(long_markdown, opt));
+console.log("should have excerpt!\n");
+
+console.log(matter(long_markdown));
+console.log("should not have excerpt!\n");
+
+console.log("################ TEST 6 ################");
+const long_markdown_different_separator = `---
+title: "long form content"
+description: "Front matter"
+categories:
+  - "test"
+  - "categories"
+---
+
+Let's add an excerpt!
+
+<!-- end -->
+
+This is content`;
+
+opt = {excerpt_separator: "<!-- end -->"};
+
+console.log(matter(long_markdown_different_separator, opt));
+console.log("should have excerpt!\n");
+
+console.log(matter(long_markdown_different_separator, {excerpt: true, excerpt_separator: "<!-- end -->"}));
+console.log("should have excerpt!\n");
+
+console.log("################ TEST 7 ################");
+const fun_markdown = `~~~
+title: "fun markdown"
+~~~
+Content`;
+
+console.log(matter(fun_markdown, {delimiters: "~~~"}));
+console.log("should not have excerpt!\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod utils;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::fmt;
 use wasm_bindgen::prelude::*;
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
@@ -9,22 +10,26 @@ use wasm_bindgen::prelude::*;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-fn extract_frontmatter(markdown_input: &str) -> Option<String> {
+fn extract_frontmatter(markdown_input: &str, delimiter: String) -> Option<String> {
     let beginning_frontmatter = &markdown_input[4..];
-    let fm_end = beginning_frontmatter.find("---\n");
+    let fm_end = beginning_frontmatter.find(&format!("{}\n", delimiter));
     if fm_end.is_none() {
         return None;
     };
-    let splits: Vec<&str> = beginning_frontmatter.split("---").collect();
+    let splits: Vec<&str> = beginning_frontmatter.split(&delimiter).collect();
     if splits.is_empty() {
         return None;
     };
     Some(splits[0].to_string())
 }
 
-fn parse_frontmatter(markdown_input: &str) -> (serde_yaml::Value, &str) {
-    let fm = match markdown_input.starts_with("---\n") {
-        true => extract_frontmatter(markdown_input),
+fn parse_frontmatter(
+    markdown_input: &str,
+    delimiters: Option<String>,
+) -> (serde_yaml::Value, &str) {
+    let delimiter = delimiters.unwrap_or("---".to_string());
+    let fm = match markdown_input.starts_with(&format!("{}\n", delimiter)) {
+        true => extract_frontmatter(markdown_input, delimiter),
         false => None,
     };
 
@@ -40,34 +45,78 @@ fn parse_frontmatter(markdown_input: &str) -> (serde_yaml::Value, &str) {
     }
 }
 
-fn parse_excerpt(markdown_input: &str) -> Option<&str> {
-    let splits: Vec<&str> = markdown_input.split("---").collect();
-    if splits.is_empty() {
-        return None;
+fn parse_excerpt(markdown_input: &str, separator: String) -> String {
+    let splits: Vec<&str> = markdown_input.split(&separator).collect();
+    if splits.len() == 1 {
+        return "".to_string();
     };
-    Some(splits[0])
+    splits[0].to_string()
 }
 
 #[derive(Serialize)]
-pub struct Data {
+struct Data {
     content: String,
     data: serde_yaml::Value,
     excerpt: String,
     //isEmpty: bool,
 }
 
+#[derive(Serialize, Deserialize)]
+struct Opt {
+    delimiters: Option<String>,
+    excerpt: Option<bool>,
+    excerpt_separator: Option<String>,
+}
+
+impl Opt {
+    fn new() -> Self {
+        Opt {
+            delimiters: Some("---".to_string()),
+            excerpt: Some(false),
+            excerpt_separator: Some("---".to_string()),
+        }
+    }
+    fn extract_options(self) -> (Option<String>, bool, String) {
+        let delimiters = self.delimiters.clone();
+        let mut excerpt = self.excerpt.clone().unwrap_or(false);
+        let excerpt_separator = self.excerpt_separator.clone().unwrap_or("---".to_string());
+        if excerpt_separator != "---".to_string() {
+            excerpt = true;
+        }
+
+        (delimiters, excerpt, excerpt_separator)
+    }
+}
+
+impl fmt::Display for Opt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "({}, {}, {})",
+            self.delimiters.clone().unwrap_or("---".to_string()),
+            self.excerpt.unwrap_or(false),
+            self.excerpt_separator.clone().unwrap_or("---".to_string()),
+        )
+    }
+}
+
 #[wasm_bindgen]
-pub fn matter(markdown_input: &str) -> JsValue {
+pub fn matter(markdown_input: &str, opt: JsValue) -> JsValue {
     utils::set_panic_hook();
 
-    let (frontmatter, content) = parse_frontmatter(markdown_input);
-    let excerpt = parse_excerpt(content);
+    let options: Opt = match opt.is_object() {
+        true => opt.into_serde().unwrap(),
+        false => Opt::new(),
+    };
+
+    let (delimiters, excerpt, excerpt_separator) = options.extract_options();
+    let (frontmatter, content) = parse_frontmatter(markdown_input, delimiters);
     let data = Data {
         content: content.to_string(),
         data: frontmatter,
         excerpt: match excerpt {
-            None => "".to_string(),
-            Some(data) => data.to_string(),
+            true => parse_excerpt(content, excerpt_separator),
+            false => "".to_string(),
         },
     };
 
@@ -77,10 +126,47 @@ pub fn matter(markdown_input: &str) -> JsValue {
 #[test]
 fn test_parse_frontmatter() {
     let test_str = "---\ntitle: Home\n---\nOther stuff";
-    let (fm, content) = parse_frontmatter(test_str);
+    let (fm, content) = parse_frontmatter(test_str, None);
 
     assert_eq!(serde_yaml::to_string(&fm).unwrap(), "---\ntitle: Home");
     assert_eq!(content.chars().count(), 11);
+}
+
+#[test]
+fn test_parse_frontmatter_with_custom_delimiter() {
+    let test_str = "~~~\ntitle: Home\n~~~\nOther stuff";
+    let (fm, content) = parse_frontmatter(test_str, Some("~~~".to_string()));
+
+    assert_eq!(serde_yaml::to_string(&fm).unwrap(), "---\ntitle: Home");
+    assert_eq!(content.chars().count(), 11);
+}
+
+#[test]
+fn test_extract_options() {
+    let opt = Opt::new();
+    let e = opt.extract_options();
+    assert_eq!(e, (Some("---".to_string()), false, "---".to_string()))
+}
+
+#[test]
+fn test_parse_excerpt() {
+    let markdown = "this is an excerpt\n---\nthis is content.";
+    let excerpt = parse_excerpt(markdown, "---".to_string());
+    assert_eq!(excerpt, "this is an excerpt\n".to_string());
+}
+
+#[test]
+fn test_parse_excerpt_no_excerpt() {
+    let markdown = "this is just content, no excerpt.";
+    let excerpt = parse_excerpt(markdown, "---".to_string());
+    assert_eq!(excerpt, "".to_string());
+}
+
+#[test]
+fn test_parse_excerpt_with_custome_delimiter() {
+    let markdown = "this is an excerpt\n<!-- end -->\nthis is content.";
+    let excerpt = parse_excerpt(markdown, "<!-- end -->".to_string());
+    assert_eq!(excerpt, "this is an excerpt\n".to_string());
 }
 
 #[test]
@@ -91,8 +177,56 @@ foo: bar
 This is an excerpt.
 ---
 This is content"#;
-    let (fm, content) = parse_frontmatter(test_str);
-    let excerpt = parse_excerpt(content);
+    let (fm, content) = parse_frontmatter(test_str, None);
+    let options = Opt::new();
+    let excerpt = parse_excerpt(content, options.excerpt_separator.unwrap());
     assert_eq!(serde_yaml::to_string(&fm).unwrap(), "---\nfoo: bar");
-    assert_eq!(excerpt.unwrap_or("").chars().count(), 20);
+    assert_eq!(excerpt.chars().count(), 20);
+}
+
+#[test]
+fn test_parse_frontmatter_with_custom_excerpt() {
+    let test_str = r#"---
+foo: bar
+---
+This is a long excerpt with custom separator.
+<!-- end -->
+This is content"#;
+    let (fm, content) = parse_frontmatter(test_str, None);
+    let options = Opt {
+        delimiters: Some("---".to_string()),
+        excerpt: Some(true),
+        excerpt_separator: Some("<!-- end -->".to_string()),
+    };
+    let excerpt = parse_excerpt(content, options.excerpt_separator.unwrap());
+    assert_eq!(serde_yaml::to_string(&fm).unwrap(), "---\nfoo: bar");
+    assert_eq!(excerpt.chars().count(), 46);
+}
+
+#[test]
+fn test_parse_frontmatter_with_no_frontmatter() {
+    let test_str = r#"This is a long excerpt with custom separator.
+---
+This is content"#;
+    let (fm, content) = parse_frontmatter(test_str, None);
+    let options = Opt::new();
+    let excerpt = parse_excerpt(content, options.excerpt_separator.unwrap());
+    assert_eq!(serde_yaml::to_string(&fm).unwrap(), "---\n{}");
+    assert_eq!(excerpt.chars().count(), 46);
+}
+
+#[test]
+fn test_parse_frontmatter_with_custom_excerpt_no_frontmatter() {
+    let test_str = r#"This is a long excerpt with custom separator.
+<!-- end -->
+This is content"#;
+    let (fm, content) = parse_frontmatter(test_str, None);
+    let options = Opt {
+        delimiters: Some("---".to_string()),
+        excerpt: Some(true),
+        excerpt_separator: Some("<!-- end -->".to_string()),
+    };
+    let excerpt = parse_excerpt(content, options.excerpt_separator.unwrap());
+    assert_eq!(serde_yaml::to_string(&fm).unwrap(), "---\n{}");
+    assert_eq!(excerpt.chars().count(), 46);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,11 +9,11 @@ pub fn set_panic_hook() {
     console_error_panic_hook::set_once();
 }
 
-//use wasm_bindgen::prelude::*;
-//#[wasm_bindgen]
-//extern "C" {
-//    // Use `js_namespace` here to bind `console.log(..)` instead of just
-//    // `log(..)`
-//    #[wasm_bindgen(js_namespace = console)]
-//    fn log(s: String);
-//}
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    // Use `js_namespace` here to bind `console.log(..)` instead of just
+    // `log(..)`
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn log(s: String);
+}


### PR DESCRIPTION
This PR adds the ability to pass options to the `matter` function controlling delimiters and excerpt separators. 