### PR TITLE
giving `matter` js_name of `default`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl Opt {
     }
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = default)
 pub fn matter(markdown_input: &str, opt: JsValue) -> JsValue {
     utils::set_panic_hook();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl Opt {
     }
 }
 
-#[wasm_bindgen(js_name = default)
+#[wasm_bindgen(js_name = default)]
 pub fn matter(markdown_input: &str, opt: JsValue) -> JsValue {
     utils::set_panic_hook();
 


### PR DESCRIPTION
I think this should remove the need to run `wasm-frontmatter` as the following:

```
import { matter } from 'wasm-frontmatter';
```

if this instead allows us to do this:

```
import matter from 'wasm-frontmatter';
```

this would be a huge win in replacement of `gray-matter` smoother...